### PR TITLE
Fix rotation counters

### DIFF
--- a/source/session/SessionStats.mc
+++ b/source/session/SessionStats.mc
@@ -306,9 +306,7 @@ class SessionStats {
         // direction = 1 (right) lub -1 (left)
         if (sessionActive) {
             totalRotations += abs(degrees);
-            rightRotations += abs(degrees);
-            leftRotations += abs(degrees);
-            
+
             if (direction != null) {
                 if (direction > 0) {
                     rightRotations += abs(degrees);


### PR DESCRIPTION
## Summary
- correct rotation tracking logic by updating `addRotation`

## Testing
- `monkeyc --version` *(fails: command not found)*
- `monkeydo` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e6aef39488331942277e79ca41701